### PR TITLE
This repo uses JSON_ALLOW_NUL which is actually from jansson 2.7.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ harb>
 - libcityhash-dev
 - libreadline-dev
 - sparsehash
-- [jansson](https://github.com/akheron/jansson) >= 2.6
+- [jansson](https://github.com/akheron/jansson) > 2.6


### PR DESCRIPTION
## Problem

I installed the jansson 2.6 and got the following compilation error:

```
g++ -m64 -g -D__STDC_FORMAT_MACROS -O3 -c -Wall main.cc -o main.o
main.cc:424:54: error: use of undeclared identifier 'JSON_ALLOW_NUL'
  json_t *o = json_loadf(f, JSON_DISABLE_EOF_CHECK | JSON_ALLOW_NUL, NULL);
                                                     ^
main.cc:425:85: error: use of undeclared identifier 'JSON_ALLOW_NUL'
  for (i = 0; o != NULL; json_decref(o), o = json_loadf(f, JSON_DISABLE_EOF_CHECK | JSON_ALLOW_NUL...
                                                                                    ^
2 errors generated.
make: *** [main.o] Error 1
```

JSON_ALLOW_NUL was added in the unreleased 2.7 version (https://github.com/akheron/jansson/blob/master/CHANGES#L19-L20)
## Solution

Installing from the latest commit in the master branch of jansson fixed the compilation error, so updated the README accordingly.
