### PR TITLE
Add dominator tree implementation for calculating retained object size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX=g++
-CXXFLAGS=-std=c++11 -m64 -g -D__STDC_FORMAT_MACROS -O0 -c -Wall
+CXXFLAGS=-std=c++11 -m64 -g -D__STDC_FORMAT_MACROS -O3 -c -Wall
 LDFLAGS=-m64 -g -ljansson -lreadline -lcityhash
 SOURCES=main.cc
 OBJECTS=$(SOURCES:.cc=.o)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX=g++
-CXXFLAGS=-std=c++11 -m64 -g -D__STDC_FORMAT_MACROS -O3 -c -Wall
+CXXFLAGS=-std=c++11 -m64 -g -D__STDC_FORMAT_MACROS -O0 -c -Wall
 LDFLAGS=-m64 -g -ljansson -lreadline -lcityhash
 SOURCES=main.cc
 OBJECTS=$(SOURCES:.cc=.o)

--- a/main.cc
+++ b/main.cc
@@ -58,6 +58,7 @@ enum ruby_value_type {
     RUBY_T_SYMBOL = 0x14,
     RUBY_T_FIXNUM = 0x15,
 
+    RUBY_T_IMEMO  = 0x1a,
     RUBY_T_UNDEF  = 0x1b,
     RUBY_T_NODE   = 0x1c,
     RUBY_T_ICLASS = 0x1d,
@@ -85,7 +86,7 @@ typedef vector<uint64_t> ruby_heap_addr_list_t;
 
 typedef struct ruby_heap_obj {
   uint32_t flags;
-  uint32_t node_num; // unique node number
+  uint32_t idx; // unique node index
   uint64_t *refs_to;
   ruby_heap_obj_list_t refs_from;
 
@@ -124,14 +125,15 @@ typedef CityHasher<const char *> CityHasherString;
 typedef sparse_hash_set<const char *, CityHasherString, eqstr> string_set_t;
 typedef sparse_hash_map<uint64_t, struct ruby_heap_obj *> ruby_heap_map_t;
 
-static const size_t kRubyObjectSize = 40;
+class dominator_tree;
 
 bool exit_ = false;
 bool show_progress;
 string_set_t intern_strings_;
 ruby_heap_map_t heap_map_;
 ruby_heap_obj_t *root_;
-uint32_t heap_obj_count_;
+dominator_tree *dominator_tree_;
+int32_t heap_obj_count_;
 FILE *out_ = stdout;
 
 static void
@@ -147,7 +149,7 @@ fatal_error(const char *fmt, ...) {
 static ruby_heap_obj_t *
 create_heap_object() {
   ruby_heap_obj_t *obj = new ruby_heap_obj_t();
-  obj->node_num = heap_obj_count_++;
+  obj->idx = ++heap_obj_count_;
   new (&obj->refs_from) ruby_heap_obj_list_t();
   return obj;
 }
@@ -238,6 +240,8 @@ get_heap_object_type(const char *type) {
     return RUBY_T_ZOMBIE;
   } else if (strcmp(type, "ROOT") == 0) {
     return RUBY_T_ROOT;
+  } else if (strcmp(type, "IMEMO") == 0) {
+    return RUBY_T_IMEMO;
   }
   return RUBY_T_NONE;
 }
@@ -295,6 +299,8 @@ get_heap_object_type_string(uint32_t type) {
     return "ZOMBIE";
   } else if (t == RUBY_T_ROOT) {
     return "ROOT";
+  } else if (t == RUBY_T_IMEMO) {
+    return "IMEMO";
   }
   return "NONE";
 }
@@ -477,6 +483,12 @@ parse_heap_object(json_t *heap_o, uint32_t type) {
       assert(json_typeof(length_o) == JSON_INTEGER);
       obj->as.obj.as.size = json_integer_value(length_o);
     }
+  } else if (type == RUBY_T_IMEMO) {
+    json_t *name_o = json_object_get(heap_o, "imemo_type");
+    if (name_o) {
+      assert(json_typeof(name_o) == JSON_STRING);
+      obj->as.obj.as.value = get_string(json_string_value(name_o));
+    }
   }
 
   json_t * memsize_o = json_object_get(heap_o, "memsize");
@@ -484,7 +496,6 @@ parse_heap_object(json_t *heap_o, uint32_t type) {
     assert(json_typeof(memsize_o) == JSON_INTEGER);
     obj->as.obj.memsize = json_integer_value(memsize_o);
   }
-  obj->as.obj.memsize += kRubyObjectSize;
 
   parse_obj_references(obj, json_object_get(heap_o, "references"));
   return obj;
@@ -551,46 +562,60 @@ parse_heap_dump(FILE *f) {
 
 class dominator_tree {
   public:
-    dominator_tree(ruby_heap_obj_t *root, uint32_t num_nodes);
+    dominator_tree(ruby_heap_obj_t *root, int32_t num_nodes);
     ~dominator_tree();
 
     void calculate();
+    void retained_size(ruby_heap_obj_t *obj, size_t &size);
 
   private:
     ruby_heap_obj_t *root;
-    uint32_t num_nodes;
-    uint32_t count;
-    uint32_t *arr;
-    uint32_t *rev;
-    uint32_t *label;
-    uint32_t *sdom;
-    uint32_t *dom;
-    uint32_t *parent;
-    uint32_t *dsu;
-    vector<uint32_t> **reverse_graph;
-    vector<uint32_t> **bucket;
+    int32_t num_nodes;
+    int32_t count;
+    int32_t *arr;
+    int32_t *rev;
+    int32_t *label;
+    int32_t *sdom;
+    int32_t *dom;
+    int32_t *parent;
+    int32_t *dsu;
+    ruby_heap_obj_t **objs;
+    vector<int32_t> **reverse_graph;
+    vector<int32_t> **bucket;
+    vector<int32_t> **tree;
+
+    Progress *progress;
 
     void dfs(ruby_heap_obj_t *node);
     void dfs_child(ruby_heap_obj_t *obj, ruby_heap_obj_t *child);
+    void calculate_sdom();
+
+    int32_t find(int32_t u, int32_t x = 0);
+    void _union(int32_t u, int32_t v);
 };
 
-dominator_tree::dominator_tree(ruby_heap_obj_t *root, uint32_t num_nodes)
-  : root(root), num_nodes(num_nodes), count(0) {
-  arr = new uint32_t[num_nodes];
-  rev = new uint32_t[num_nodes];
-  label = new uint32_t[num_nodes];
-  sdom = new uint32_t[num_nodes];
-  dom = new uint32_t[num_nodes];
-  parent = new uint32_t[num_nodes];
-  dsu = new uint32_t[num_nodes];
+dominator_tree::dominator_tree(ruby_heap_obj_t *root, int32_t num_nodes)
+  : root(root), num_nodes(num_nodes + 1), count(0) {
+  arr = new int32_t[num_nodes];
+  rev = new int32_t[num_nodes];
+  label = new int32_t[num_nodes];
+  sdom = new int32_t[num_nodes];
+  dom = new int32_t[num_nodes];
+  parent = new int32_t[num_nodes];
+  dsu = new int32_t[num_nodes];
+  objs = new ruby_heap_obj_t*[num_nodes];
 
-  reverse_graph = new vector<uint32_t>*[num_nodes];
-  bucket = new vector<uint32_t>*[num_nodes];
+  reverse_graph = new vector<int32_t>*[num_nodes];
+  bucket = new vector<int32_t>*[num_nodes];
+  tree = new vector<int32_t>*[num_nodes];
 
-  for (uint32_t i = 0; i < this->num_nodes; ++i) {
-    reverse_graph[i] = new vector<uint32_t>();
-    bucket[i] = new vector<uint32_t>();
+  for (int32_t i = 0; i < this->num_nodes; ++i) {
+    reverse_graph[i] = new vector<int32_t>();
+    bucket[i] = new vector<int32_t>();
+    tree[i] = new vector<int32_t>();
   }
+
+  progress = new Progress("generating dominator tree", num_nodes * 3);
 }
 
 dominator_tree::~dominator_tree() {
@@ -600,19 +625,24 @@ dominator_tree::~dominator_tree() {
   delete sdom;
   delete parent;
   delete dsu;
+  delete objs;
 
-  for (uint32_t i = 0; i < this->num_nodes; ++i) {
+  for (int32_t i = 0; i < this->num_nodes; ++i) {
     delete reverse_graph[i];
     delete bucket[i];
+    delete tree[i];
   }
   delete reverse_graph;
   delete bucket;
+  delete tree;
+
+  delete progress;
 }
 
 void
 dominator_tree::dfs_child(ruby_heap_obj_t *obj, ruby_heap_obj_t *child) {
-  uint32_t u = obj->node_num;
-  uint32_t w = child->node_num;
+  int32_t u = obj->idx;
+  int32_t w = child->idx;
 
   if (!arr[w]) {
     dfs(child);
@@ -625,11 +655,14 @@ dominator_tree::dfs_child(ruby_heap_obj_t *obj, ruby_heap_obj_t *child) {
 void
 dominator_tree::dfs(ruby_heap_obj_t *obj) {
   count++;
-  arr[obj->node_num] = count;
-  rev[count] = obj->node_num;
+  arr[obj->idx] = count;
+  rev[count] = obj->idx;
   label[count] = count;
   sdom[count] = count;
   dsu[count] = count;
+  objs[obj->idx] = obj;
+
+  progress->increment();
 
   if (likely((!is_root_object(obj) || !obj->as.root.children) && obj->refs_to)) {
     for (uint32_t i = 0; obj->refs_to[i]; ++i) {
@@ -637,7 +670,7 @@ dominator_tree::dfs(ruby_heap_obj_t *obj) {
       if (child) {
         dfs_child(obj, child);
       } else {
-        printf("warning: could not find object 0x%" PRIx64 " in heap dump\n", obj->refs_to[i]);
+        /* printf("warning: could not find object 0x%" PRIx64 " in heap dump\n", obj->refs_to[i]); */
       }
     }
   } else if (obj == root) {
@@ -647,16 +680,102 @@ dominator_tree::dfs(ruby_heap_obj_t *obj) {
   }
 }
 
-void
-dominator_tree::calculate() {
-  dfs(root);
+int32_t
+dominator_tree::find(int32_t u, int32_t x) {
+  if (u == dsu[u]) {
+    return x ? -1 : u;
+  }
+
+  int32_t v = find(dsu[u], x + 1);
+  if (v < 0) {
+    return u;
+  }
+
+  if (sdom[label[dsu[u]]] < sdom[label[u]]) {
+    label[u] = label[dsu[u]];
+  }
+
+  dsu[u] = v;
+  return x ? v : label[u];
 }
 
-static void
-build_dominator_tree(ruby_heap_obj_t *root) {
-  auto tree = new dominator_tree(root, heap_obj_count_);
-  tree->calculate();
-  delete tree;
+void
+dominator_tree::_union(int32_t u, int32_t v) {
+  dsu[v] = u;
+}
+
+void
+dominator_tree::calculate_sdom() {
+  for (int32_t i = count; i >= 1; i--) {
+    for (uint32_t j = 0; j < reverse_graph[i]->size(); j++) {
+      sdom[i] = min(sdom[i], sdom[find((*reverse_graph[i])[j])]);
+    }
+
+    if (i > 1) {
+      bucket[sdom[i]]->push_back(i);
+    }
+
+    for (uint32_t j = 0; j < bucket[i]->size(); j++) {
+      int32_t w = (*bucket[i])[j];
+      int32_t v = find(w);
+
+      if (sdom[v] == sdom[w]) {
+        dom[w] = sdom[w];
+      } else {
+        dom[w] = v;
+      }
+    }
+
+    if (i > 1) {
+      _union(parent[i], i);
+    }
+
+    progress->increment();
+  }
+}
+
+void
+dominator_tree::calculate() {
+  progress->start();
+
+  dfs(root);
+
+  progress->update(num_nodes);
+
+  calculate_sdom();
+
+  progress->update(num_nodes * 2);
+
+  for (int32_t i = 2; i <= count; i++) {
+    if (dom[i] != sdom[i]) {
+      dom[i] = dom[dom[i]];
+    }
+
+    tree[rev[i]]->push_back(rev[dom[i]]);
+    tree[rev[dom[i]]]->push_back(rev[i]);
+    progress->increment();
+  }
+
+  progress->complete();
+}
+
+void
+dominator_tree::retained_size(ruby_heap_obj_t *obj, size_t &size) {
+  size += is_root_object(obj) ? 0 : obj->as.obj.memsize;
+
+  if (obj != root) {
+    auto t = tree[obj->idx];
+    if (t->size() == 1) {
+      return;
+    } else {
+      for (size_t i = 1; i < t->size(); i++) {
+        ruby_heap_obj_t *obj = objs[(*t)[i]];
+        retained_size(obj, size);
+      }
+    }
+  }
+
+  return;
 }
 
 static const char *
@@ -720,7 +839,7 @@ print_object(ruby_heap_obj_t *obj) {
       name_title = "struct";
       p = obj->as.obj.as.value;
     } else if (type == RUBY_T_OBJECT || type == RUBY_T_ICLASS) {
-      name_title = "name";
+      name_title = type == RUBY_T_OBJECT ? "class" : "name";
       ruby_heap_obj_t *clazz = heap_map_[obj->as.obj.class_addr];
       assert(clazz);
       p = clazz->as.obj.as.value;
@@ -732,8 +851,11 @@ print_object(ruby_heap_obj_t *obj) {
       p = obj->as.obj.as.value;
     } else if (type == RUBY_T_HASH || type == RUBY_T_ARRAY) {
       name_title = "length";
-      sprintf(buf, "%d", obj->as.obj.as.size);
+      sprintf(buf, "%'d", obj->as.obj.as.size);
       p = buf;
+    } else if (type == RUBY_T_IMEMO) {
+      name_title = "imemo_type";
+      p = obj->as.obj.as.value;
     }
     if (name_title) {
       printf("%18s: %s%s%s\n", name_title,
@@ -742,7 +864,11 @@ print_object(ruby_heap_obj_t *obj) {
         type == RUBY_T_STRING ? "\"" : "");
     }
 
-    printf("%18s: %zu\n", "size", obj->as.obj.memsize);
+    printf("%18s: %'zu\n", "memsize", obj->as.obj.memsize);
+
+    size_t retained_size = 0;
+    dominator_tree_->retained_size(obj, retained_size);
+    printf("%18s: %'zu\n", "retained memsize", retained_size);
 
     if (obj->flags & RUBY_FL_SHARED) {
       printf("%18s: %s\n", "shared", "true");
@@ -1022,7 +1148,8 @@ main(int argc, char **argv) {
 
   parse_heap_dump(heap_file);
 
-  build_dominator_tree(root_);
+  dominator_tree_ = new dominator_tree(root_, heap_obj_count_);
+  dominator_tree_->calculate();
 
   while (!exit_) {
     line = readline("harb> ");


### PR DESCRIPTION
This adds an [implementation](https://tanujkhattar.wordpress.com/2016/01/11/dominator-tree-of-a-directed-graph/) of a [dominator tree](https://en.wikipedia.org/wiki/Dominator_(graph_theory)) that is used to calculate the total memory retained by an object by examining all of the objects that it dominates in the heap graph.

Calculation of the dominator tree is performed at startup. 

The initial functionality simply adds the retained memory size of an object to the `print` command, which includes the memory usage of all objects dominated by the object specified, e.g. the total amount of memory used by the `Gem` module:
```
harb> print 0x7fd95a8396a0
    0x7fd95a8396a0: "MODULE"
              name: Gem
           memsize: 4,000
  retained memsize: 900,010
     references to: [
...
```

The addition of a dominator tree opens the door to a bunch of other useful functionality (e.g. finding objects that are using a lot of memory).