### PR TITLE
Page output with less

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifdef DEBUG
   CXXFLAGS += -O0 -UNDEBUG
 endif
 LDFLAGS=-m64 -g -lreadline
-SOURCES=main.cc ruby_heap_obj.cc parser.cc graph.cc dominator_tree.cc progress.cc
+SOURCES=main.cc ruby_heap_obj.cc parser.cc graph.cc dominator_tree.cc progress.cc output.cc
 OBJECTS=$(SOURCES:.cc=.o)
 EXECUTABLE=harb
 

--- a/output.cc
+++ b/output.cc
@@ -1,0 +1,8 @@
+#include "output.h"
+
+namespace harb {
+
+bool Output::use_pager_ = true;
+
+}
+

--- a/output.h
+++ b/output.h
@@ -1,0 +1,36 @@
+#include <stdio.h>
+#include <unistd.h>
+
+namespace harb {
+
+class Output {
+  static bool use_pager_;
+
+public:
+  static void initialize() {
+    if (isatty(fileno(stdin))) {
+      use_pager_ = true;
+    } else {
+      use_pager_ = false;
+    }
+  }
+
+  template<typename Func> static void with_handle(Func func) {
+    FILE *output;
+    if (use_pager_) {
+      output = popen("/usr/bin/less -XF", "w");
+    } else {
+      output = stdout;
+    }
+
+    func(output);
+
+    if (output != stdout) {
+      pclose(output);
+    }
+  }
+};
+
+
+}
+

--- a/ruby_heap_obj.h
+++ b/ruby_heap_obj.h
@@ -128,9 +128,9 @@ public:
 
   const char * get_object_summary(char *buf, size_t buf_sz);
 
-  void print_ref_object();
+  void print_ref_object(FILE *);
 
-  void print_object();
+  void print_object(FILE *);
 
   static RubyValueType get_value_type(const char *str);
   static const char * get_value_type_string(uint32_t type);


### PR DESCRIPTION
Adds a new class, `Output`, that should be used for anything that writes output to the screen. The method `with_handle` accepts a lambda that accepts a `FILE *` argument, which is a handle that can be written to with `fprintf` for example. If running in a TTY, output will be paged with `less`.