### PR TITLE
Display symbol values

### DIFF
--- a/ruby_heap_obj.cc
+++ b/ruby_heap_obj.cc
@@ -188,7 +188,7 @@ void RubyHeapObj::print_object(FILE *out) {
     } else if (type == RUBY_T_OBJECT || type == RUBY_T_ICLASS) {
       name_title = type == RUBY_T_OBJECT ? "class" : "name";
       p = get_class_obj()->get_value();
-    } else if (type == RUBY_T_STRING) {
+    } else if (type == RUBY_T_STRING || type == RUBY_T_SYMBOL) {
       name_title = "value";
       p = get_value();
     } else if (type == RUBY_T_CLASS || type == RUBY_T_MODULE) {


### PR DESCRIPTION
Before:

```
harb> print 0x560e047f9ff0
    0x560e047f9ff0: "SYMBOL"
           memsize: 40
  retained memsize: 40
...
```

After
```
harb> print 0x560e047f9ff0
    0x560e047f9ff0: "SYMBOL"
             value: handle_order_edit
           memsize: 40
  retained memsize: 40
...
```

On side note, most symbols actually have a reference on their equivalent fstring:

https://github.com/ruby/ruby/blob/e6aa0a61fac94f16250412b8ac80657dd9d6d572/symbol.c#L790-L799

Too bad it's not dumped by `ObjectSpace.dump`, I'll see if I can get a patch upstream.

@csfrancis 