### PR TITLE
Update type numbers for Ruby values

### DIFF
--- a/ruby_heap_obj.cc
+++ b/ruby_heap_obj.cc
@@ -65,6 +65,8 @@ RubyValueType RubyHeapObj::get_value_type(const char *type) {
     return RUBY_T_UNDEF;
   } else if (strcmp(type, "ZOMBIE") == 0) {
     return RUBY_T_ZOMBIE;
+  } else if (strcmp(type, "MOVED") == 0) {
+    return RUBY_T_MOVED;
   } else if (strcmp(type, "ROOT") == 0) {
     return RUBY_T_ROOT;
   } else if (strcmp(type, "IMEMO") == 0) {
@@ -123,6 +125,8 @@ const char * RubyHeapObj::get_value_type_string(uint32_t type) {
     return "UNDEF";
   } else if (t == RUBY_T_ZOMBIE) {
     return "ZOMBIE";
+  } else if (t == RUBY_T_MOVED) {
+    return "MOVED";
   } else if (t == RUBY_T_ROOT) {
     return "ROOT";
   } else if (t == RUBY_T_IMEMO) {

--- a/ruby_heap_obj.h
+++ b/ruby_heap_obj.h
@@ -31,12 +31,13 @@ enum RubyValueType {
     RUBY_T_FALSE  = 0x13,
     RUBY_T_SYMBOL = 0x14,
     RUBY_T_FIXNUM = 0x15,
+    RUBY_T_UNDEF  = 0x16,
 
     RUBY_T_IMEMO  = 0x1a,
-    RUBY_T_UNDEF  = 0x1b,
-    RUBY_T_NODE   = 0x1c,
-    RUBY_T_ICLASS = 0x1d,
-    RUBY_T_ZOMBIE = 0x1e,
+    RUBY_T_NODE   = 0x1b,
+    RUBY_T_ICLASS = 0x1c,
+    RUBY_T_ZOMBIE = 0x1d,
+    RUBY_T_MOVED  = 0x1e,
 
     RUBY_T_MASK   = 0x1f
 };


### PR DESCRIPTION
Was poking around Ruby's heap dumper and realized that type numbers were not updated.

When `T_IMEMO` was introduced back then in 2015, type numbers were modified:
https://github.com/ruby/ruby/commit/0952b43b9be23688702368f6fcae3fde2dd69fb5#diff-3b256c5581538dcd834697c766a2b1aaR453-R456.

This PR updates the type numbers for ruby value types and adds a new `RUBY_T_MOVED` type (which will only be used in Ruby 2.7.x: https://github.com/ruby/ruby/commit/91793b8967e0531bd1159a8ff0cc7e50739c7620).

cc: @csfrancis 