### PR TITLE
Add missing headers to fix compilation

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -8,6 +8,7 @@
 #include <sys/errno.h>
 #include <unistd.h>
 #include <locale.h>
+#include <stdarg.h>
 
 #include <readline/readline.h>
 #include <readline/history.h>

--- a/ruby_heap_obj.h
+++ b/ruby_heap_obj.h
@@ -2,6 +2,8 @@
 #define HARB_RUBY_HEAP_OBJ_H
 
 #include <unistd.h>
+#include <stdio.h>
+#include <stdint.h>
 
 #include <vector>
 


### PR DESCRIPTION
Hey! Thanks a lot for harb, I'm using it to debug a few flaky tests that rely on garbage collection.

I ran into a few errors when trying to compile harb on Ubuntu 22.04 (gcc 11.4.0):

```
main.cc:35:3: error: ‘va_start’ was not declared in this scope
   35 |   va_start(args, fmt);
      |   ^~~~~~~~

ruby_heap_obj.h:132:25: error: ‘FILE’ has not been declared
  132 |   void print_ref_object(FILE *);
      |                         ^~~~

ruby_heap_obj.h:64:21: error: ‘uint64_t’ was not declared in this scope
   64 | typedef std::vector<uint64_t> RubyHeapAddrList;
      |                     ^~~~~~~~
```

Adding these headers fixes compilation.